### PR TITLE
rename args/buildArgs to flags/buildFlags, use external nix file for …

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,29 +18,11 @@ As a result `nix-build-uncached` will built all packages,
 not present in the binary cache.
 
 ```
-$ nix-env -f ./ci.nix --drv-path -qaP * --xml --meta
-$ nix-build --dry-run ./ci.nix.nix
-/nix/store/j68qphj95cx65xsxadgmy9wa08dlbjrq-hello-2.10.drv
+../nix-build-unchached/nix-build-uncached non-broken.nix
+$ nix-env -f non-broken.nix --drv-path -qaP * --xml --meta
+$ nix-build --dry-run non-broken.nix
 1/40 attribute(s) will be built:
   hello-nur
-$ nix-build ./ci.nix -k -A hello-nur
-these derivations will be built:
-  /nix/store/j68qphj95cx65xsxadgmy9wa08dlbjrq-hello-2.10.drv
-building '/nix/store/j68qphj95cx65xsxadgmy9wa08dlbjrq-hello-2.10.drv' on 'ssh://nix@martha.r'...
-copying path '/nix/store/3x7dwzq014bblazs7kq20p9hyzz0qh8g-hello-2.10.tar.gz' from 'https://cache.nixos.org'...
-unpacking sources
-unpacking source archive /nix/store/3x7dwzq014bblazs7kq20p9hyzz0qh8g-hello-2.10.tar.gz
-source root is hello-2.10
-setting SOURCE_DATE_EPOCH to timestamp 1416139241 of file hello-2.10/ChangeLog
-patching sources
-configuring
-...
-shrinking RPATHs of ELF executables and libraries in /nix/store/k2z0nxgz2pm2d6lbc6v7r0gfxvil5ns2-hello-2.10
-shrinking /nix/store/k2z0nxgz2pm2d6lbc6v7r0gfxvil5ns2-hello-2.10/bin/hello
-gzipping man pages under /nix/store/k2z0nxgz2pm2d6lbc6v7r0gfxvil5ns2-hello-2.10/share/man/
-strip is /nix/store/p1y0xl8dp4s1x1vvxxb5sn84wj6lsh8s-binutils-2.31.1/bin/strip
-stripping (with command strip and flags -S) in /nix/store/k2z0nxgz2pm2d6lbc6v7r0gfxvil5ns2-hello-2.10/bin
-patching script interpreter paths in /nix/store/k2z0nxgz2pm2d6lbc6v7r0gfxvil5ns2-hello-2.10
-checking for references to /build/ in /nix/store/k2z0nxgz2pm2d6lbc6v7r0gfxvil5ns2-hello-2.10...
-/nix/store/k2z0nxgz2pm2d6lbc6v7r0gfxvil5ns2-hello-2.10
+$ nix build -f /tmp/859272287.nix --keep-going
+[1 built, 1 copied (0.2 MiB)]
 ```

--- a/test/test.nix
+++ b/test/test.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import <nixpkgs> {} }:
+{ pkgs ? import <nixpkgs> {}}:
 {
   test = pkgs.writeText "test" "test";
   inherit (pkgs) hello;

--- a/test/test.sh
+++ b/test/test.sh
@@ -6,9 +6,11 @@ dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 store=$(mktemp -p "$dir" -d)
 outputs=$(mktemp -p "$dir" -d)
 trap "{ chmod -R +w $store; rm -rf $store $outputs; }" EXIT
-go run $dir/.. -args "--store '$store'" -build-args "-o '$outputs/result'" $dir/test.nix
+
+go run $dir/.. -flags "--store '$store'" -build-flags "-o '$outputs/result1'" $dir/test.nix
+go run $dir/.. -flags "--store '$store'" -build-flags "-o '$outputs/result2'" $dir/test2.nix
 count=$(find "$outputs" -type l | wc -l)
 
-if [[ $count != "1" ]]; then
-    echo "expect one package to be built, got $count"
+if [[ $count != "2" ]]; then
+    echo "expect two package to be built, got $count"
 fi

--- a/test/test2.nix
+++ b/test/test2.nix
@@ -1,0 +1,6 @@
+with import <nixpkgs> {};
+{
+  attrSet = recurseIntoAttrs {
+    test = pkgs.writeText "test2" "test";
+  };
+}


### PR DESCRIPTION
…filtering

The latter change will work around large attribute sets that no longer
fit into argv.