### PR TITLE
Fix "failed setting rlimit: invalid argument" on osx

### DIFF
--- a/build.go
+++ b/build.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"syscall"
 )
@@ -80,6 +81,9 @@ func raiseFdLimit() (uint64, error) {
 	if rlimit.Cur < rlimit.Max {
 		oldVal := rlimit.Cur
 		rlimit.Cur = rlimit.Max
+		if runtime.GOOS == "darwin" && rlimit.Cur > 24576 {
+			rlimit.Cur = 24576
+		}
 		err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rlimit)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "failed setting rlimit: %s", err)


### PR DESCRIPTION
Running on osx, the attempt to change the rlimit fails with "invalid argument".

It appears that the value of rlimit.Max is `9223372036854775807`, and that
trying to set to that value fails. More on this at
https://github.com/golang/go/issues/30401.

We fix this by setting the value to the somewhat magic 24576 when on osx (darwin).