### PR TITLE
relax matching for dry-run parsing

### DIFF
--- a/build.go
+++ b/build.go
@@ -38,10 +38,10 @@ func parseMissingDrvs(output *bytes.Buffer) map[string]bool {
 	missingDrvs := make(map[string]bool)
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.HasPrefix(line, "these paths will be fetched") || strings.HasPrefix(line, "don't know how to build these paths") {
+		if strings.Contains(line, "paths will be fetched") || strings.HasPrefix(line, "don't know how to build these paths") {
 			break
 		}
-		if strings.HasPrefix(line, "these derivations will be built:") {
+		if strings.Contains(line, "derivations will be built:") {
 			found = true
 		} else if found {
 			drv := strings.TrimLeft(line, " ")


### PR DESCRIPTION
Fixes #23. disclaimer: I didn't test extensively (with an older daemon for example).