### PR TITLE
Further relax output matching

### DIFF
--- a/build.go
+++ b/build.go
@@ -41,7 +41,7 @@ func parseMissingDrvs(output *bytes.Buffer) map[string]bool {
 		if strings.Contains(line, "paths will be fetched") || strings.HasPrefix(line, "don't know how to build these paths") {
 			break
 		}
-		if strings.Contains(line, "derivations will be built:") {
+		if strings.Contains(line, "will be built:") {
 			found = true
 		} else if found {
 			drv := strings.TrimLeft(line, " ")


### PR DESCRIPTION
Related https://github.com/Mic92/nix-build-uncached/issues/23 https://github.com/Mic92/nix-build-uncached/pull/24

Special case for singular :joy: 
```
$ nix-build --dry-run ./ci.nix -o results/x
this derivation will be built:
  /nix/store/vcszzmj4bzng9pr5wmk4j3d5y2v545ka-ny.drv
```