### PR TITLE
use nix-build as build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,6 @@ unnecessary downloads even if no package has been changed.
 
 `nix-build-uncached` is available in nixpkgs.
 
-For nix versions bigger than 2.3.x you need to enable at least
-`experimental-features = nix-command` in your `/etc/nix/nix.conf` or
-`$HOME/.config/nix/nix.conf` or pass `-build-flags "--experimental-features nix-command"`
-to `nix-build-uncached`.
-
 In the following example ci.nix contains all expressions
 that should be built. Since only `hello-nur` is not yet in
 the binary cache, all other packages are skipped.

--- a/build.go
+++ b/build.go
@@ -85,7 +85,6 @@ func raiseFdLimit() (uint64, error) {
 }
 
 func nixBuild(drvs map[string]bool, buildArgs []string) error {
-	buildArgs = append([]string{"build"}, buildArgs...)
 	numBuildChars := len("nix") + 1
 	for _, arg := range buildArgs {
 		numBuildChars += len(arg) + 1
@@ -107,7 +106,7 @@ func nixBuild(drvs map[string]bool, buildArgs []string) error {
 	for drv := range drvs {
 		n := len(drv) + 1
 		if n+numChars > MAX_CHARS || uint64(len(args)-len(buildArgs)) >= maxConcurrentBuilds {
-			cmd := Command("nix", args...)
+			cmd := Command("nix-build", args...)
 			if err := cmd.Run(); err != nil {
 				return err
 			}
@@ -118,7 +117,7 @@ func nixBuild(drvs map[string]bool, buildArgs []string) error {
 		numChars += n
 	}
 	if numChars > numBuildChars {
-		cmd := Command("nix", args...)
+		cmd := Command("nix-build", args...)
 		if err := cmd.Run(); err != nil {
 			return err
 		}


### PR DESCRIPTION
So that users don't have to enable experimental features, and to work around https://github.com/NixOS/nix/issues/7220, use `nix-build` instead of `nix build`.