### PR TITLE
fix usage with nix 2.15

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,11 @@ jobs:
     - run:
         nix-build -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixpkgs-unstable.tar.gz
     - run:
-        nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixpkgs-unstable.tar.gz --pure --run "TEST_ASSETS=$(pwd)/test NIX_SSL_CERT_FILE=$NIX_SSL_CERT_FILE go test"
+        nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixpkgs-unstable.tar.gz --pure --run "TMPDIR=/tmp TEST_ASSETS=$(pwd)/test NIX_SSL_CERT_FILE=$NIX_SSL_CERT_FILE go test"
+      # tests rely on `--store`, which is not supported on macOS
+      if: matrix.os == 'ubuntu-latest'
+    - run:
+        nix-shell --argstr nixVersion nix_2_15 -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/nixpkgs-unstable.tar.gz --pure --run "TMPDIR=/tmp TEST_ASSETS=$(pwd)/test NIX_SSL_CERT_FILE=$NIX_SSL_CERT_FILE go test"
       # tests rely on `--store`, which is not supported on macOS
       if: matrix.os == 'ubuntu-latest'
     - run:

--- a/bors.toml
+++ b/bors.toml
@@ -1,2 +1,5 @@
 cut_body_after = "" # don't include text from the PR body in the merge commit message
-status = [ "tests" ]
+status = [
+  "tests (macos-latest)",
+  "tests (ubuntu-latest)"
+]

--- a/build.go
+++ b/build.go
@@ -114,7 +114,7 @@ func nixBuild(drvs map[string]bool, buildArgs []string) error {
 			numChars = numBuildChars
 			args = buildArgs
 		}
-		args = append(args, drv)
+		args = append(args, drv+"^*")
 		numChars += n
 	}
 	if numChars > numBuildChars {

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,8 @@
-{ pkgs ? import <nixpkgs> {} }:
-with pkgs;
-buildGoModule {
+{ pkgs ? import <nixpkgs> {}, nixVersion ? null }:
+let
+   nix = if nixVersion == null then pkgs.nix else pkgs.nixVersions.${nixVersion};
+in
+pkgs.buildGoModule {
   pname = "nix-build-uncached";
   version = "1.0.0";
   src = ./.;
@@ -8,11 +10,11 @@ buildGoModule {
   modSha256 = "1fl0wb1xj4v4whqm6ivzqjpac1iwpq7m12g37gr4fpgqp8kzi6cn";
   vendorSha256 = null;
 
-  nativeBuildInputs = [ makeWrapper delve ];
+  nativeBuildInputs = [ pkgs.makeWrapper pkgs.delve ];
 
   shellHook = ''
     # needed for tests
-    export PATH=$PATH:${lib.makeBinPath [ nix ]}
+    export PATH=${pkgs.lib.makeBinPath [ nix ]}:$PATH
   '';
 
   # requires nix, which we do not have in the sandbox

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 
@@ -10,6 +11,25 @@ import (
 type options struct {
 	buildFlags   string
 	installables []string
+}
+
+type nixVersion struct {
+	Major, Minor, Patch uint64
+}
+
+func getNixVersion() (nixVersion, error) {
+	var version nixVersion
+	cmd := Command("nix", "--version")
+	var outb bytes.Buffer
+	cmd.Stdout = &outb
+	if err := cmd.Run(); err != nil {
+		return version, err
+	}
+	_, err := fmt.Sscanf(outb.String(), "nix (Nix) %d.%d.%d", &version.Major, &version.Minor, &version.Patch)
+	if err != nil {
+		return version, err
+	}
+	return version, nil
 }
 
 func parseFlags(args []string) (*options, error) {
@@ -25,7 +45,6 @@ func parseFlags(args []string) (*options, error) {
 			continue
 		} else if args[i] == "-flags" {
 			return nil, fmt.Errorf("option '-flags' is deprecated. You can now pass all those flags directly to nix-build-uncached")
-
 		}
 		opts.installables = append(opts.installables, args[i])
 	}
@@ -43,8 +62,12 @@ func realMain(args []string) error {
 	if err != nil {
 		return fmt.Errorf("Value passed to -build-flags is not valid: %s", err)
 	}
+	version, err := getNixVersion()
+	if err != nil {
+		return fmt.Errorf("Failed to get nix version: %s", err)
+	}
 
-	if _, err := buildUncached(opts.installables, buildFlags); err != nil {
+	if _, err := buildUncached(opts.installables, buildFlags, version); err != nil {
 		return fmt.Errorf("%s", err)
 	}
 


### PR DESCRIPTION
warning: The interpretation of store paths arguments ending in`.drv` recently changed. If this command is now failing try again with '/nix/store/m5raazy9x0zm8p732y001aqypds0hb2m-gebaar-libinput-+6ce14eb.drv^*'

this will break nix 2.15< but i don't know enough golang to make it conditional so help needed

fixes https://github.com/Mic92/nix-build-uncached/issues/52


There's most likely dozens of silently broken CI right now so it's important to get this in and to nixpkgs