### PR TITLE
Support evaluating flake outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,10 @@ $ nix build --builders   /nix/store/s5alllpjx9fmdj26mf9cmxzs3xyxjn7f-hello-2.00.
 
 ### Flakes
 
-We cannot support flakes directly at the time because `nix-build` does
-not accept those and `nix build`'s `--no-dry-run` is broken.
-However it is possible to add a wrapper nix expression that imports a flake.
-The following example imports hydra jobs from a nix flake the same directory.
-It assumes that the flake also has `nixpkgs` in its inputs.
+Specific flake inputs are supported as they will be evaluated by `nix derivation
+show`. It is also possible to add a wrapper nix expression that imports a flake
+in its entirety: the following example imports hydra jobs from a nix flake the same
+directory. It assumes that the flake also has `nixpkgs` in its inputs.
 
 ```nix
 let


### PR DESCRIPTION
The README notes that `nix-build` cannot build flake outputs and that `nix build` is unsuitable for properly building uncached derivations, but there's another approach we can take: `nix derivation show` will evaluate any inputs and print their contents as JSON.

We don't actually care about the derivations' contents, only the actual derivation that gets written to disk as part of the evaluation. We can take that plain-old derivation file and pass it to `nix-build` and everything works out!